### PR TITLE
add useGpu option to build_jar.py

### DIFF
--- a/build_jar.py
+++ b/build_jar.py
@@ -19,7 +19,7 @@ if __name__ == '__main__':
     '''
     Example:
 
-    ./build_jar.py --os linux-x86_64
+    ./build_jar.py --os linux-x86_64 --useGpu true
     '''
     parser = argparse.ArgumentParser(description='Build a pipelines JAR.')
 
@@ -35,6 +35,9 @@ if __name__ == '__main__':
                         help='whether to use pmml or not,'
                             ' not encouraged if agpl license is an issue')
 
+    parser.add_argument('--useGpu', type=str, default='false',
+                        help='whether to use CUDA backend or not')
+
     parser.add_argument('--source', type=str,
                         help='the path to the model server',default='.')
 
@@ -46,7 +49,7 @@ if __name__ == '__main__':
     command += ' -Djavacpp.platform=' + args.os + ' '
     if 'arm' in args.os:
         command += '-Dchip=arm'
-    elif 'gpu' in args.os:
+    elif strtobool(args.useGpu):
         command += ' -Dchip=gpu'
     else:
         command += ' -Dchip=cpu'

--- a/client/README.md
+++ b/client/README.md
@@ -7,12 +7,13 @@ To install this Python package, run `python setup.py install`. To run any exampl
 
 ```bash
 cd ..
-python build_jar.py -- os <your-platform>
+python build_jar.py --os <your-platform>
 ```
 
-where `<your-platform>` is picked from `windows-x86_64`,`linux-x86_64`,`linux-x86_64-gpu`,
-`macosx-x86_64`, `linux-armhf` and `windows-x86_64-gpu`, depending on your operating system
+where `<your-platform>` is picked from `windows-x86_64`, `linux-x86_64`,
+`macosx-x86_64`, `linux-armhf`, depending on your operating system
 and architecture. 
+Add `--useGpu true` if you want to take advantage of GPU acceleration.
 
 ## Running tests
 


### PR DESCRIPTION
I added `--useGpu` option to build_jar.py so that it can be built with cuda support. #4
Relevant part of README.md in the client directory was modified too.

Ignore this pull request if `--os linux-x86_64-gpu` will become working in the future.